### PR TITLE
model.send(@progress, val) error if @progress is not specified

### DIFF
--- a/lib/carrierwave/video/ffmpeg_options.rb
+++ b/lib/carrierwave/video/ffmpeg_options.rb
@@ -24,7 +24,7 @@ module CarrierWave
       end
 
       def progress(model)
-        lambda {|val| model.send(@progress, val)}
+        lambda {|val| model.send(@progress, val)} if @progress
       end
 
       def encoder_options


### PR DESCRIPTION
if we don't handle video converting progress it will perform model.send(nil) and raise error.

Original Error backtrace: 

Failed to transcode with FFmpeg. Check ffmpeg install and verify video is not corrupt or cut short. Original error: nil is not a symbol\n/home/aeliseev/pecaa/shared/bundle/ruby/1.9.1/gems/carrierwave-video-0.5.2/lib/carrierwave/video.rb:89:in `rescue in with_trancoding_callbacks
