### PR TITLE
Adds possibility to inherit bitrate from uploaded file

### DIFF
--- a/lib/carrierwave/video.rb
+++ b/lib/carrierwave/video.rb
@@ -51,6 +51,10 @@ module CarrierWave
         @options.format_options[:resolution] = file.resolution
       end
 
+      if opts[:video_bitrate] == :same
+        @options.format_options[:video_bitrate] = file.video_bitrate
+      end
+
       yield(file, @options.format_options) if block_given?
 
       progress = @options.progress(model)


### PR DESCRIPTION
For instance, when uploading a mp4 that should be converted to a webm, use the uploaded file bitrate as a target bitrate
