### PR TITLE
Do not pass watermark option to ffmpeg because it is processed wrong

### DIFF
--- a/lib/carrierwave/video/ffmpeg_options.rb
+++ b/lib/carrierwave/video/ffmpeg_options.rb
@@ -42,6 +42,7 @@ module CarrierWave
       # output
       def format_params
         params = @format_options.dup
+        params.delete(:watermark)
         params[:custom] = [params[:custom], watermark_params].compact.join(' ')
         params
       end

--- a/spec/lib/carrierwave_video_spec.rb
+++ b/spec/lib/carrierwave_video_spec.rb
@@ -207,6 +207,18 @@ describe CarrierWave::Video do
           path: 'path/to/file.png'
         })
       end
+
+      it "removes watermark options from common options" do
+        movie.should_receive(:transcode) do |path, opts, codec_opts|
+          opts.should_not have_key(:watermark)
+        end
+
+        converter.encode_video(format, watermark: {
+          path: 'path/to/file.png',
+          position: :bottom_left,
+          pixels_from_edge: 5
+        })
+      end
     end
 
     context "with resolution set to :same" do


### PR DESCRIPTION
After https://github.com/streamio/streamio-ffmpeg has added own way to add watermark option `watermark` is processed with wrong way. So we should remove this option from options list before pass them to ffmpeg.

It closes https://github.com/rheaton/carrierwave-video/issues/23

It will be better in future to use native way to apply watermark.
