### PR TITLE
Allow real custom options and errors to actually bubble up

### DIFF
--- a/lib/carrierwave/video.rb
+++ b/lib/carrierwave/video.rb
@@ -80,7 +80,7 @@ module CarrierWave
           setup_logger
           block.call
           send_callback(callbacks[:after_transcode])
-        rescue => e
+        rescue UploadError
           send_callback(callbacks[:rescue])
 
           if logger
@@ -90,7 +90,8 @@ module CarrierWave
             end
           end
 
-          raise CarrierWave::ProcessingError.new("Failed to transcode with FFmpeg. Check ffmpeg install and verify video is not corrupt or cut short. Original error: #{e}")
+          raise e
+
         ensure
           reset_logger
           send_callback(callbacks[:ensure])

--- a/lib/carrierwave/video/ffmpeg_options.rb
+++ b/lib/carrierwave/video/ffmpeg_options.rb
@@ -5,7 +5,7 @@ module CarrierWave
 
       def initialize(format, options)
         @format = format.to_s
-        @resolution = options[:resolution] || "640x360"
+        @resolution = options[:resolution]
         @custom = options[:custom]
         @callbacks = options[:callbacks] || {}
         @logger = options[:logger]
@@ -31,7 +31,7 @@ module CarrierWave
       end
 
       def encoder_options
-        { preserve_aspect_ratio: :width }
+        { }
       end
 
       # input
@@ -76,7 +76,7 @@ module CarrierWave
       private
 
         def defaults
-          @defaults ||= { resolution: '640x360', watermark: {} }.tap do |h|
+          @defaults ||= { watermark: {} }.tap do |h|
             case format
             when 'mp4'
               h[:video_codec] = 'libx264'


### PR DESCRIPTION
Removes the default resolution of 640x360 (why was it set to that in the
first place?).

preserve_aspect_ratio is also something that I wanted to handle myself
with the `custom` calling code.

Using similar ffmpeg options in MediaCrush, here is a valid way for this
gem to be used:

```ruby
process encode_video: [:mp4,
  custom: "-vcodec libx264 -an -pix_fmt yuv420p -profile:v baseline " +
          "-preset slower -crf 18 " +
          "-vf 'scale=trunc(in_w/2)*2:trunc(in_h/2)*2' -map 0:v:0"]
```