### PR TITLE
Feature/encoder options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -37,6 +37,14 @@ Pass in options to process:
 Resolution passed to ffmpeg:
     resolution: "640x360"
 
+Also, you can preserve initial video's aspect ratio by changing one of result's resolutions:
+    preserve_aspect_ratio: :width
+to change height of the video, depending on it's width (default value),
+    preserve_aspect_ratio: :height
+to change width of the video, depending on it's height, or
+    preserve_aspect_ratio: false
+to leave resolution unchanged
+
 If you want to keep the same resolution:
 
 Note: This only works with the edge version of streamio-ffmpeg (as of Feb 28, 2014) https://github.com/streamio/streamio-ffmpeg/issues/72

--- a/lib/carrierwave/video/ffmpeg_options.rb
+++ b/lib/carrierwave/video/ffmpeg_options.rb
@@ -11,6 +11,7 @@ module CarrierWave
         @logger = options[:logger]
         @unparsed = options
         @progress = options[:progress]
+        @preserve_aspect_ratio = options[:preserve_aspect_ratio] || :width
 
         @format_options = defaults.merge(options)
       end
@@ -31,7 +32,7 @@ module CarrierWave
       end
 
       def encoder_options
-        { preserve_aspect_ratio: :width }
+        { preserve_aspect_ratio: @preserve_aspect_ratio }
       end
 
       # input


### PR DESCRIPTION
Rebased @par0v0zik's pull request to get passing specs.

I think his code is a fine addition to carrierwave-video and preserves the existing functionality since it will default to 'width' if you don't pick anything.