### PR TITLE
Replace streamio-ffmpeg with rlovelett-ffmpeg

### DIFF
--- a/carrierwave-video.gemspec
+++ b/carrierwave-video.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.3.0"
   s.add_development_dependency "rake"
 
-  s.add_runtime_dependency 'streamio-ffmpeg'
+  s.add_runtime_dependency 'rlovelett-ffmpeg'
   s.add_runtime_dependency 'carrierwave'
   s.requirements << 'ruby, version 1.9 or greater'
   s.requirements << 'ffmpeg, version 0.11.1 or greater with libx256, libfaac, libtheora, libvorbid, libvpx enabled'

--- a/lib/carrierwave/video.rb
+++ b/lib/carrierwave/video.rb
@@ -1,4 +1,4 @@
-require 'streamio-ffmpeg'
+require 'rlovelett-ffmpeg'
 require 'carrierwave'
 require 'carrierwave/video/ffmpeg_options'
 require 'carrierwave/video/ffmpeg_theora'
@@ -25,12 +25,12 @@ module CarrierWave
 
     end
 
-    def encode_ogv(opts)
+    def encode_ogv(opts={})
       # move upload to local cache
       cache_stored_file! if !cached?
 
-      tmp_path  = File.join( File.dirname(current_path), "tmpfile.ogv" )
       @options = CarrierWave::Video::FfmpegOptions.new('ogv', opts)
+      tmp_path = File.join( File.dirname(current_path), "tmpfile.ogv" )
 
       with_trancoding_callbacks do
         transcoder = CarrierWave::Video::FfmpegTheora.new(current_path, tmp_path)

--- a/lib/carrierwave/video/ffmpeg_options.rb
+++ b/lib/carrierwave/video/ffmpeg_options.rb
@@ -81,16 +81,16 @@ module CarrierWave
             case format
             when 'mp4'
               h[:video_codec] = 'libx264'
-              h[:audio_codec] = 'libfaac'
+              h[:audio_codec] = 'libfdk_aac'
               h[:custom] = '-qscale 0 -preset slow -g 30'
             when 'ogv'
               h[:video_codec] = 'libtheora'
               h[:audio_codec] = 'libvorbis'
-              h[:custom] = '-b 1500k -ab 160000 -g 30'
+              h[:custom] = '-b:v 1500k -b:a 160000 -g 30'
             when 'webm'
               h[:video_codec] = 'libvpx'
               h[:audio_codec] = 'libvorbis'
-              h[:custom] = '-b 1500k -ab 160000 -f webm -g 30'
+              h[:custom] = '-b:v 1500k -b:a 160000 -f webm -g 30'
             end
           end
         end

--- a/lib/carrierwave/video/ffmpeg_options.rb
+++ b/lib/carrierwave/video/ffmpeg_options.rb
@@ -81,7 +81,7 @@ module CarrierWave
             case format
             when 'mp4'
               h[:video_codec] = 'libx264'
-              h[:audio_codec] = 'libfdk_aac'
+              h[:audio_codec] = 'libfaac'
               h[:custom] = '-qscale 0 -preset slow -g 30'
             when 'ogv'
               h[:video_codec] = 'libtheora'

--- a/spec/lib/carrierwave_video_spec.rb
+++ b/spec/lib/carrierwave_video_spec.rb
@@ -57,7 +57,7 @@ describe CarrierWave::Video do
 
           expect(opts[:video_codec]).to eq('libvpx')
           expect(opts[:audio_codec]).to eq('libvorbis')
-          expect(opts[:custom]).to eq('-b 1500k -ab 160000 -f webm -g 30')
+          expect(opts[:custom]).to eq('-b:v 1500k -b:a 160000 -f webm -g 30')
 
           expect(path).to eq("video/path/tmpfile.#{format}")
         end
@@ -179,7 +179,7 @@ describe CarrierWave::Video do
 
           expect(opts[:video_codec]).to eq('libvpx')
           expect(opts[:audio_codec]).to eq('libvorbis')
-          expect(opts[:custom]).to eq("-b 1500k -ab 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay=5:main_h-overlay_h-5 [out]\"")
+          expect(opts[:custom]).to eq("-b:v 1500k -b:a 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay=5:main_h-overlay_h-5 [out]\"")
 
           expect(path).to eq("video/path/tmpfile.#{format}")
         end
@@ -197,7 +197,7 @@ describe CarrierWave::Video do
 
           expect(opts[:video_codec]).to eq('libvpx')
           expect(opts[:audio_codec]).to eq('libvorbis')
-          expect(opts[:custom]).to eq("-b 1500k -ab 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay= [out]\"")
+          expect(opts[:custom]).to eq("-b:v 1500k -b:a 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay= [out]\"")
 
           expect(path).to eq("video/path/tmpfile.#{format}")
         end
@@ -262,7 +262,7 @@ describe CarrierWave::Video do
     context "given a block" do
       let(:movie) { double }
       let(:opts) { {} }
-      let(:params) { { resolution: "640x360", watermark: {}, video_codec: "libvpx", audio_codec: "libvorbis", custom: "-b 1500k -ab 160000 -f webm -g 30" } }
+      let(:params) { { resolution: "640x360", watermark: {}, video_codec: "libvpx", audio_codec: "libvorbis", custom: "-b:v 1500k -b:a 160000 -f webm -g 30" } }
 
       before do
         expect(File).to receive(:rename)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'streamio-ffmpeg'
+require 'rlovelett-ffmpeg'
 require 'carrierwave/video'
 
 RSpec.configure do |config|


### PR DESCRIPTION
The PR replaces `streamio-ffmpeg` with `rlovelett-ffmpeg`.
`rlovelett-ffmpe` uses `ffprobe` for metadata parsing which is less error-prone. I had severe problems detecting the resolution and `resolution: :same` didn't worked for my videos.
See the PR: https://github.com/streamio/streamio-ffmpeg/pull/73#issuecomment-99315284

It also updates the defaults to get rid of the ambiguous warnings. Let me know if you are happy with the changes.