### PR TITLE
Fix ArgumentError while encoding video (issue #46)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.3.0

--- a/carrierwave-video.gemspec
+++ b/carrierwave-video.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'streamio-ffmpeg'
   s.add_runtime_dependency 'carrierwave'
-  s.requirements << 'ruby, version 1.9 or greater'
+  s.requirements << 'ruby, version 2.3.0 or greater'
   s.requirements << 'ffmpeg, version 0.11.1 or greater with libx256, libfaac, libtheora, libvorbid, libvpx enabled'
 end

--- a/lib/carrierwave/video.rb
+++ b/lib/carrierwave/video.rb
@@ -90,7 +90,8 @@ module CarrierWave
             end
           end
 
-          raise CarrierWave::ProcessingError.new("Failed to transcode with FFmpeg. Check ffmpeg install and verify video is not corrupt or cut short. Original error: #{e}")
+          raise e
+
         ensure
           reset_logger
           send_callback(callbacks[:ensure])

--- a/lib/carrierwave/video/ffmpeg_options.rb
+++ b/lib/carrierwave/video/ffmpeg_options.rb
@@ -44,7 +44,7 @@ module CarrierWave
       def format_params
         params = @format_options.dup
         params.delete(:watermark)
-        params[:custom] = [params[:custom], watermark_params].compact.join(' ')
+        params[:custom] = [params[:custom], watermark_params].compact.join(' ').split(' ')
         params
       end
 
@@ -77,7 +77,7 @@ module CarrierWave
       private
 
         def defaults
-          @defaults ||= { resolution: '640x360', watermark: {} }.tap do |h|
+          @defaults ||= { resolution: @resolution, watermark: {} }.tap do |h|
             case format
             when 'mp4'
               h[:video_codec] = 'libx264'

--- a/spec/lib/carrierwave_video_spec.rb
+++ b/spec/lib/carrierwave_video_spec.rb
@@ -57,7 +57,7 @@ describe CarrierWave::Video do
 
           expect(opts[:video_codec]).to eq('libvpx')
           expect(opts[:audio_codec]).to eq('libvorbis')
-          expect(opts[:custom]).to eq('-b 1500k -ab 160000 -f webm -g 30')
+          expect(opts[:custom]).to eq('-b 1500k -ab 160000 -f webm -g 30'.split(' '))
 
           expect(path).to eq("video/path/tmpfile.#{format}")
         end
@@ -103,7 +103,6 @@ describe CarrierWave::Video do
         let(:e) { StandardError.new("test error") }
         before { expect(File).to receive(:rename).and_raise(e) }
 
-
         it "calls before_transcode and ensure" do
           expect(converter.model).to receive(:method1).with(format, opts).ordered
           expect(converter.model).not_to receive(:method2)
@@ -112,7 +111,7 @@ describe CarrierWave::Video do
 
           expect do
             converter.encode_video(format, opts)
-          end.to raise_exception(CarrierWave::ProcessingError)
+          end.to raise_exception(e.class)
         end
       end
     end
@@ -145,7 +144,7 @@ describe CarrierWave::Video do
 
           expect do
             converter.encode_video(format, logger: :logger)
-          end.to raise_exception(CarrierWave::ProcessingError)
+          end.to raise_exception(e.class)
         end
       end
     end
@@ -180,7 +179,7 @@ describe CarrierWave::Video do
 
           expect(opts[:video_codec]).to eq('libvpx')
           expect(opts[:audio_codec]).to eq('libvorbis')
-          expect(opts[:custom]).to eq("-b 1500k -ab 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay=5:main_h-overlay_h-5 [out]\"")
+          expect(opts[:custom]).to eq("-b 1500k -ab 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay=5:main_h-overlay_h-5 [out]\"".split(' '))
 
           expect(path).to eq("video/path/tmpfile.#{format}")
         end
@@ -198,7 +197,7 @@ describe CarrierWave::Video do
 
           expect(opts[:video_codec]).to eq('libvpx')
           expect(opts[:audio_codec]).to eq('libvorbis')
-          expect(opts[:custom]).to eq("-b 1500k -ab 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay= [out]\"")
+          expect(opts[:custom]).to eq("-b 1500k -ab 160000 -f webm -g 30 -vf \"movie=path/to/file.png [logo]; [in][logo] overlay= [out]\"".split(' '))
 
           expect(path).to eq("video/path/tmpfile.#{format}")
         end
@@ -243,15 +242,15 @@ describe CarrierWave::Video do
 
       it "takes the provided custom param" do
         expect(movie).to receive(:transcode) do |path, opts, codec_opts|
-          expect(opts[:custom]).to eq('-preset slow') # a la changes in ffmpeg 0.11.1
+          expect(opts[:custom]).to eq(%w(-preset slow)) # a la changes in ffmpeg 0.11.1
         end
 
-        converter.encode_video(format, custom: '-preset slow')
+        converter.encode_video(format, custom: %w(-preset slow))
       end
 
       it "maintains the watermark params" do
         expect(movie).to receive(:transcode) do |path, opts, codec_opts|
-          expect(opts[:custom]).to eq("-preset slow -vf \"movie=path/to/file.png [logo]; [in][logo] overlay= [out]\"")
+          expect(opts[:custom]).to eq("-preset slow -vf \"movie=path/to/file.png [logo]; [in][logo] overlay= [out]\"".split(' '))
         end
 
         converter.encode_video(format, custom: '-preset slow', watermark: {
@@ -285,7 +284,7 @@ describe CarrierWave::Video do
         block = Proc.new { |input, params| params[:custom] = '-preset slow' }
 
         expect(movie).to receive(:transcode) do |path, format_opts, codec_opts|
-          expect(format_opts[:custom]).to eq('-preset slow')
+          expect(format_opts[:custom]).to eq(%w(-preset slow))
         end
 
         converter.encode_video(format, opts, &block)
@@ -298,7 +297,7 @@ describe CarrierWave::Video do
         end
 
         expect(movie).to receive(:transcode) do |path, format_opts, codec_opts|
-          expect(format_opts[:custom]).to eq('-preset slow -vf "movie=customized/path [logo]; [in][logo] overlay= [out]"')
+          expect(format_opts[:custom]).to eq('-preset slow -vf "movie=customized/path [logo]; [in][logo] overlay= [out]"'.split(' '))
         end
 
         converter.encode_video(format, opts, &block)


### PR DESCRIPTION
[Since `streamio-ffmpeg` only accepts Array as a :custom parameter](https://github.com/streamio/streamio-ffmpeg/blob/master/lib/ffmpeg/encoding_options.rb#L192), it was throwing an `ArgumentError` while trying to pass a string there. Fixed now